### PR TITLE
feat: ensure throughput data spans time unit intervals

### DIFF
--- a/client/src/datasets/reports/components/filter-form/filter-options-form.tsx
+++ b/client/src/datasets/reports/components/filter-form/filter-options-form.tsx
@@ -4,13 +4,13 @@ import { Col, Form, Row, Select, SelectProps, Tag } from "antd";
 import { RangeType } from "../date-picker";
 import { DateSelector } from "../date-selector";
 import { isNil, map, pipe, reject, uniq } from "rambda";
-import { formatDate } from "../../../../lib/format";
 import { useFilterContext } from "../../../../filter/context";
 import { defaultDateRange } from "../../../../lib/intervals";
 import {
   ExpandableOptions,
   ExpandableOptionsHeader,
 } from "../../../../components/expandable-options";
+import { formatDate } from "../../../../lib/format";
 
 export type FilterOptions = {
   hierarchyLevel?: HierarchyLevel;

--- a/client/src/lib/intervals.ts
+++ b/client/src/lib/intervals.ts
@@ -40,7 +40,7 @@ const startOf = (date: Date, unit: TimeUnit): Date => {
   }
 };
 
-const overlappingEndOf = (date: Date, start: Date, unit: TimeUnit): Date => {
+const endOf = (date: Date, start: Date, unit: TimeUnit): Date => {
   switch (unit) {
     case TimeUnit.Day:
       return endOfDay(date);
@@ -60,11 +60,11 @@ export const getOverlappingInterval = (
   unit: TimeUnit,
 ): Interval => {
   const start = startOf(interval.start, unit);
-  const end = overlappingEndOf(interval.end, start, unit);
+  const end = endOf(interval.end, start, unit);
   return { start, end };
 };
 
-export const getOverlap = (
+export const getIntersectingInterval = (
   interval1: Interval,
   interval2: Interval,
 ): Interval | undefined => {

--- a/client/src/lib/throughput.ts
+++ b/client/src/lib/throughput.ts
@@ -1,13 +1,7 @@
 import { range } from "rambda";
 import { quantileSeq } from "mathjs";
 import { CompletedIssue } from "../data/issues";
-import {
-  Interval,
-  TimeUnit,
-  addTime,
-  difference,
-  getOverlappingInterval,
-} from "./intervals";
+import { Interval, TimeUnit, addTime, difference } from "./intervals";
 
 export type CalculateThroughputParams = {
   issues: CompletedIssue[];
@@ -35,17 +29,16 @@ export type ThroughputResult = {
 
 export const calculateThroughput = ({
   issues,
-  interval,
+  interval: { start, end },
   timeUnit,
 }: CalculateThroughputParams): ThroughputResult => {
-  const { start, end } = getOverlappingInterval(interval, timeUnit);
-
-  const intervals = range(0, difference(end, start, timeUnit) + 1).map(
-    (index) => ({
-      start: addTime(start, index, timeUnit),
-      end: addTime(start, index + 1, timeUnit),
-    }),
-  );
+  const intervals = range(
+    0,
+    Math.floor(difference(end, start, timeUnit)) + 1,
+  ).map((index) => ({
+    start: addTime(start, index, timeUnit),
+    end: addTime(start, index + 1, timeUnit),
+  }));
 
   const data = intervals.map(({ start, end }) => {
     const intervalIssues = issues.filter(

--- a/client/src/lib/time-spent.ts
+++ b/client/src/lib/time-spent.ts
@@ -1,6 +1,6 @@
 import { isNil, pipe, reject, sortBy, sum } from "rambda";
 import { HierarchyLevel, Issue } from "../data/issues";
-import { Interval, getOverlap } from "./intervals";
+import { Interval, getIntersectingInterval } from "./intervals";
 import { differenceInSeconds } from "date-fns";
 
 export type TimeSpentRow = Pick<Issue, "key" | "summary"> &
@@ -30,7 +30,7 @@ export const timeSpentInPeriod = (
         const overlaps = reject(isNil)(
           issue.transitions.map((transition) =>
             transition.toStatus.category === "In Progress"
-              ? getOverlap(period, {
+              ? getIntersectingInterval(period, {
                   start: transition.date,
                   end: transition.until,
                 })


### PR DESCRIPTION
TODO
- [x] Decouple filter dates from selected dates. Dates for filtering should be computed based on (a) selected dates and (b) time units.