### PR TITLE
fix: don't exclude in progress issues with resolution filter

### DIFF
--- a/.changeset/early-carpets-jump.md
+++ b/.changeset/early-carpets-jump.md
@@ -1,0 +1,5 @@
+---
+"@agileplanning-io/flow-metrics": patch
+---
+
+feat: add FilterUseCase to filterIssues function

--- a/packages/metrics/src/issues/filter.spec.ts
+++ b/packages/metrics/src/issues/filter.spec.ts
@@ -1,6 +1,6 @@
 import { buildIssue } from "../fixtures/issue-factory";
 import { HierarchyLevel } from "../issues";
-import { FilterType, filterIssues } from "./filter";
+import { FilterType, FilterUseCase, filterIssues } from "./filter";
 
 describe("filterIssues", () => {
   const story = buildIssue({ hierarchyLevel: HierarchyLevel.Story });
@@ -90,7 +90,7 @@ describe("filterIssues", () => {
     const duplicateStory = { ...story, resolution: "Duplicate" };
 
     it("includes resolutions", () => {
-      const filteredIssues = filterIssues([doneStory, duplicateStory], {
+      const filteredIssues = filterIssues([doneStory, duplicateStory, story], {
         resolutions: {
           values: ["Done"],
           type: FilterType.Include,
@@ -101,14 +101,29 @@ describe("filterIssues", () => {
     });
 
     it("excludes resolutions", () => {
-      const filteredIssues = filterIssues([doneStory, duplicateStory], {
+      const filteredIssues = filterIssues([doneStory, duplicateStory, story], {
         resolutions: {
           values: ["Done"],
           type: FilterType.Exclude,
         },
       });
 
-      expect(filteredIssues).toEqual([duplicateStory]);
+      expect(filteredIssues).toEqual([duplicateStory, story]);
+    });
+
+    it("applies the resolution filter selectively in the metrics use case", () => {
+      const filteredIssues = filterIssues(
+        [doneStory, duplicateStory, story],
+        {
+          resolutions: {
+            values: ["Done"],
+            type: FilterType.Exclude,
+          },
+        },
+        FilterUseCase.Metrics,
+      );
+
+      expect(filteredIssues).toEqual([duplicateStory, story]);
     });
   });
 

--- a/packages/metrics/src/issues/filter.ts
+++ b/packages/metrics/src/issues/filter.ts
@@ -60,7 +60,27 @@ const matchValuesFilter = (
   return true;
 };
 
-export const filterIssues = (issues: Issue[], filter: IssueFilter): Issue[] => {
+/**
+ * The filtering use case.
+ */
+export enum FilterUseCase {
+  /**
+   * When simply listing issues, we should apply all filter criteria as specified.
+   */
+  List = "list",
+
+  /**
+   * When applying filters for metrics, we should only apply the resolution filter if there is a
+   * resolution. Otherwise we omit started issues from the cycle time/age.
+   */
+  Metrics = "metrics",
+}
+
+export const filterIssues = (
+  issues: Issue[],
+  filter: IssueFilter,
+  useCase: FilterUseCase = FilterUseCase.List,
+): Issue[] => {
   return issues.filter((issue) => {
     if (filter.hierarchyLevel) {
       if (issue.hierarchyLevel !== filter.hierarchyLevel) {
@@ -68,7 +88,13 @@ export const filterIssues = (issues: Issue[], filter: IssueFilter): Issue[] => {
       }
     }
 
-    if (!matchValuesFilter(filter.resolutions, issue.resolution)) {
+    const shouldApplyResolutionFilter =
+      (useCase === FilterUseCase.Metrics && issue.resolution) ||
+      useCase === FilterUseCase.List;
+    if (
+      shouldApplyResolutionFilter &&
+      !matchValuesFilter(filter.resolutions, issue.resolution)
+    ) {
       return false;
     }
 

--- a/packages/metrics/src/metrics/flow-metrics.ts
+++ b/packages/metrics/src/metrics/flow-metrics.ts
@@ -1,4 +1,4 @@
-import { HierarchyLevel, Issue } from "../issues";
+import { FilterUseCase, HierarchyLevel, Issue } from "../issues";
 import { filterIssues } from "../issues";
 import { getStatusFlowMetrics } from "./policies/status-flow-metrics";
 import { getComputedFlowMetrics } from "./policies/computed-flow-metrics";
@@ -53,7 +53,7 @@ const filterStories =
   ([stories, epics]: PartitionedIssues): PartitionedIssues => {
     return [
       policy.epics.type === "computed"
-        ? filterIssues(stories, policy.epics)
+        ? filterIssues(stories, policy.epics, FilterUseCase.Metrics)
         : stories,
       epics,
     ];


### PR DESCRIPTION
Previously the stories policy for computed cycle times would, if it included a resolution filter, exclude all in progress issues (i.e. those without a resolution) from any metrics. This was OK for completed epics, but for ageing epics the start time might be nonsensical (since in progress issues were ignored).

This PR clarifies that there are two use cases for filtering: listing issues (when we typically want to apply all filters as specified) and for metrics (when we want to be more intelligent about which filters apply).